### PR TITLE
Update ansible task to remove unsupported npm_proxy module params

### DIFF
--- a/roles/npm-management/tasks/main.yml
+++ b/roles/npm-management/tasks/main.yml
@@ -45,8 +45,6 @@
     host: "{{npm_api_host}}"
     state: present
     ssl_forced: "{{npm_api_ssl_forced}}"
-    delegate_to: localhost
-    throttle: 1
   when:
     - npm_access_token
     - npm_api_domain_name is defined


### PR DESCRIPTION
Amazing project, thanks so much!

When playing around with this locally, the task as defined fails:

```
TASK [../../ngnix-proxy-manager-mgmt : Create Proxy-Host an NPM] *********************************************************************************************************************************
fatal: [192.168.1.2]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (npm_proxy) module: throttle. Supported parameters include: domain, host, host_port, ssl_forced, state, token, url."}
```

This PR removes the unsupported params from the task, so that it can run as expected. 